### PR TITLE
feat: 서버 배포 및 mysql 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 
-//	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+//	runtimeOnly 'com.h2database:h2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`server-deploy` -> `main`

### 변경 사항
- MySQL 커넥터 의존성 추가
    ```groovy
    runtimeOnly 'com.mysql:mysql-connector-j'
    ```

### 테스트 결과
- 애플리케이션이 MySQL 데이터베이스에 정상적으로 연결됨
- 데이터베이스 연동 기능 확인