### PR TITLE
feat: jar 파일 생성 false

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.5'
 }
 
+jar {
+	enabled = false
+}
+
 group = 'adhd'
 version = '0.0.1-SNAPSHOT'
 


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`server-deploy` -> `main`

### 변경 사항
- JAR 파일 생성을 비활성화
    ```groovy
    jar {
        enabled = false
    }
    ```

### 테스트 결과
- `jar` 파일이 더 이상 생성되지 않음
- 빌드 과정에서 JAR 파일 생성 비활성화 확인
