### PR TITLE
feature: 일기장 분석

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ dependencies {
 
 	implementation 'com.auth0:java-jwt:4.2.1'
 
-//	runtimeOnly 'com.mysql:mysql-connector-j'
-	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+//	runtimeOnly 'com.h2database:h2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -34,13 +34,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	implementation 'com.auth0:java-jwt:4.2.1'
 
-	runtimeOnly 'com.mysql:mysql-connector-j'
-//	runtimeOnly 'com.h2database:h2'
+//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/adhd/diary/DiaryApplication.java
+++ b/src/main/java/adhd/diary/DiaryApplication.java
@@ -9,5 +9,4 @@ public class DiaryApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(DiaryApplication.class, args);
 	}
-
 }

--- a/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
@@ -4,6 +4,7 @@ import adhd.diary.chatgpt.dto.ChatMessage;
 import adhd.diary.chatgpt.service.ChatGptService;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,13 +16,16 @@ public class ChatGptController {
 
     private final ChatGptService chatGptService;
 
+    @Value("${chatgpt.analyze}")
+    private String analyzeSentence;
+
     public ChatGptController(ChatGptService chatGptService) {
         this.chatGptService = chatGptService;
     }
 
     @PostMapping("/chatgpt/diary-analyze")
     public CompletableFuture<ResponseEntity<String>> createChatCompletion(@RequestParam String diaryContents) {
-        return chatGptService.analyzeDiaryContents(List.of(new ChatMessage(diaryContents)))
+        return chatGptService.analyzeDiaryContents(List.of(new ChatMessage(diaryContents + analyzeSentence)))
                 .thenApply(ResponseEntity::ok)
                 .exceptionally(e -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error : " + e.getMessage()));
     }

--- a/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
@@ -1,0 +1,28 @@
+package adhd.diary.chatgpt.controller;
+
+import adhd.diary.chatgpt.dto.ChatMessage;
+import adhd.diary.chatgpt.service.ChatGptService;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ChatGptController {
+
+    private final ChatGptService chatGptService;
+
+    public ChatGptController(ChatGptService chatGptService) {
+        this.chatGptService = chatGptService;
+    }
+
+    @PostMapping("/chatgpt/diary-analyze")
+    public CompletableFuture<ResponseEntity<String>> createChatCompletion(@RequestParam String diaryContents) {
+        return chatGptService.analyzeDiaryContents(List.of(new ChatMessage(diaryContents)))
+                .thenApply(ResponseEntity::ok)
+                .exceptionally(e -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error : " + e.getMessage()));
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionChoice.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionChoice.java
@@ -1,15 +1,29 @@
 package adhd.diary.chatgpt.dto;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChatCompletionChoice {
 
-    Integer index;
+    private Integer index;
 
     @JsonAlias("delta")
-    ChatMessage message;
+    private ChatMessage message;
 
     @JsonProperty("finish_reason")
-    String finishReason;
+    private String finishReason;
+
+    public Integer getIndex() {
+        return index;
+    }
+
+    public ChatMessage getMessage() {
+        return message;
+    }
+
+    public String getFinishReason() {
+        return finishReason;
+    }
 }

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionChoice.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionChoice.java
@@ -1,0 +1,15 @@
+package adhd.diary.chatgpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ChatCompletionChoice {
+
+    Integer index;
+
+    @JsonAlias("delta")
+    ChatMessage message;
+
+    @JsonProperty("finish_reason")
+    String finishReason;
+}

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
@@ -12,8 +12,8 @@ public class ChatCompletionRequest {
     private List<ChatMessage> messages;
 
     @JsonProperty("max_tokens")
-//    @Value("${chatgpt.max-tokens}")
-    private Integer maxTokens = 1000;
+    @Value("${chatgpt.max-tokens}")
+    private Integer maxTokens;
 
     public ChatCompletionRequest(List<ChatMessage> messages) {
         this.messages = messages;

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
@@ -7,13 +7,13 @@ import org.springframework.beans.factory.annotation.Value;
 public class ChatCompletionRequest {
 
     @Value("${chatgpt.model}")
-    private String model;
+    private String model = "gpt-3.5-turbo-0125";
 
     private List<ChatMessage> messages;
 
     @JsonProperty("max_tokens")
-    @Value("${chatgpt.max-tokens}")
-    private Integer maxTokens;
+//    @Value("${chatgpt.max-tokens}")
+    private Integer maxTokens = 1000;
 
     public ChatCompletionRequest(List<ChatMessage> messages) {
         this.messages = messages;

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
@@ -1,0 +1,37 @@
+package adhd.diary.chatgpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+
+public class ChatCompletionRequest {
+
+    @Value("${chatgpt.model}")
+    private String model;
+
+    private List<ChatMessage> messages;
+
+    @JsonProperty("max_tokens")
+    @Value("${chatgpt.max-tokens}")
+    private Integer maxTokens;
+
+    public ChatCompletionRequest(List<ChatMessage> messages) {
+        this.messages = messages;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public List<ChatMessage> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<ChatMessage> messages) {
+        this.messages = messages;
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionResponse.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionResponse.java
@@ -1,56 +1,13 @@
 package adhd.diary.chatgpt.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
-public class ChatCompletionResponse {
-
-    private String id;
-
-    private String object;
-
-    private long created;
-
-    private String model;
-
-    private List<ChatCompletionChoice> choices;
-
-    private Usage usage;
-
-    public ChatCompletionResponse(String id,
-                                  String object,
-                                  long created,
-                                  String model,
-                                  List<ChatCompletionChoice> choices,
-                                  Usage usage) {
-        this.id = id;
-        this.object = object;
-        this.created = created;
-        this.model = model;
-        this.choices = choices;
-        this.usage = usage;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getObject() {
-        return object;
-    }
-
-    public long getCreated() {
-        return created;
-    }
-
-    public String getModel() {
-        return model;
-    }
-
-    public List<ChatCompletionChoice> getChoices() {
-        return choices;
-    }
-
-    public Usage getUsage() {
-        return usage;
-    }
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ChatCompletionResponse(String id,
+                                     String object,
+                                     long created,
+                                     String model,
+                                     List<ChatCompletionChoice> choices,
+                                     Usage usage) {
 }

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionResponse.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionResponse.java
@@ -1,4 +1,56 @@
 package adhd.diary.chatgpt.dto;
 
+import java.util.List;
+
 public class ChatCompletionResponse {
+
+    private String id;
+
+    private String object;
+
+    private long created;
+
+    private String model;
+
+    private List<ChatCompletionChoice> choices;
+
+    private Usage usage;
+
+    public ChatCompletionResponse(String id,
+                                  String object,
+                                  long created,
+                                  String model,
+                                  List<ChatCompletionChoice> choices,
+                                  Usage usage) {
+        this.id = id;
+        this.object = object;
+        this.created = created;
+        this.model = model;
+        this.choices = choices;
+        this.usage = usage;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    public long getCreated() {
+        return created;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public List<ChatCompletionChoice> getChoices() {
+        return choices;
+    }
+
+    public Usage getUsage() {
+        return usage;
+    }
 }

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionResponse.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionResponse.java
@@ -1,0 +1,4 @@
+package adhd.diary.chatgpt.dto;
+
+public class ChatCompletionResponse {
+}

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatMessage.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatMessage.java
@@ -2,7 +2,7 @@ package adhd.diary.chatgpt.dto;
 
 public class ChatMessage {
 
-    private String role = "user";
+    private String role;
     private String content;
 
     public ChatMessage(String role, String content) {
@@ -29,13 +29,5 @@ public class ChatMessage {
 
     public void setContent(String content) {
         this.content = content;
-    }
-
-    @Override
-    public String toString() {
-        return "ChatMessage{" +
-                "role='" + role + '\'' +
-                ", content='" + content + '\'' +
-                '}';
     }
 }

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatMessage.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatMessage.java
@@ -1,0 +1,41 @@
+package adhd.diary.chatgpt.dto;
+
+public class ChatMessage {
+
+    private String role = "user";
+    private String content;
+
+    public ChatMessage(String role, String content) {
+        this.role = role;
+        this.content = content;
+    }
+
+    public ChatMessage(String content) {
+        this.role = "user";
+        this.content = content;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @Override
+    public String toString() {
+        return "ChatMessage{" +
+                "role='" + role + '\'' +
+                ", content='" + content + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatMessage.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatMessage.java
@@ -5,6 +5,9 @@ public class ChatMessage {
     private String role;
     private String content;
 
+    public ChatMessage() {
+    }
+
     public ChatMessage(String role, String content) {
         this.role = role;
         this.content = content;

--- a/src/main/java/adhd/diary/chatgpt/dto/Usage.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/Usage.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Usage {
 
     @JsonProperty("prompt_tokens")
-    long promptTokens;
+    private long promptTokens;
 
     @JsonProperty("completion_tokens")
-    long completionTokens;
+    private long completionTokens;
 
     @JsonProperty("total_tokens")
-    long totalTokens;
+    private long totalTokens;
+
+    public Usage() {
+    }
 
     public Usage(long promptTokens,
                  long completionTokens,

--- a/src/main/java/adhd/diary/chatgpt/dto/Usage.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/Usage.java
@@ -1,0 +1,35 @@
+package adhd.diary.chatgpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Usage {
+
+    @JsonProperty("prompt_tokens")
+    long promptTokens;
+
+    @JsonProperty("completion_tokens")
+    long completionTokens;
+
+    @JsonProperty("total_tokens")
+    long totalTokens;
+
+    public Usage(long promptTokens,
+                 long completionTokens,
+                 long totalTokens) {
+        this.promptTokens = promptTokens;
+        this.completionTokens = completionTokens;
+        this.totalTokens = totalTokens;
+    }
+
+    public long getPromptTokens() {
+        return promptTokens;
+    }
+
+    public long getCompletionTokens() {
+        return completionTokens;
+    }
+
+    public long getTotalTokens() {
+        return totalTokens;
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/service/ChatGptService.java
+++ b/src/main/java/adhd/diary/chatgpt/service/ChatGptService.java
@@ -1,0 +1,30 @@
+package adhd.diary.chatgpt.service;
+
+import adhd.diary.chatgpt.dto.ChatCompletionRequest;
+import adhd.diary.chatgpt.dto.ChatMessage;
+import adhd.diary.chatgpt.util.ChatGptUtil;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatGptService {
+
+    @Value("${openai.url.prompt}")
+    private String API_URL;
+
+    private final ChatGptUtil chatGptUtil;
+
+    public ChatGptService(ChatGptUtil chatGptUtil) {
+        this.chatGptUtil = chatGptUtil;
+    }
+
+    public CompletableFuture<String> analyzeDiaryContents(List<ChatMessage> messages) {
+        return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
+    }
+
+    public ChatCompletionRequest toChatCompletionRequest(List<ChatMessage> messages) {
+        return new ChatCompletionRequest(messages);
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/util/ChatGptUtil.java
+++ b/src/main/java/adhd/diary/chatgpt/util/ChatGptUtil.java
@@ -1,6 +1,8 @@
 package adhd.diary.chatgpt.util;
 
 import adhd.diary.chatgpt.dto.ChatCompletionRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -11,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 public class ChatGptUtil {
 
     private final HttpClient client = HttpClient.newBuilder().build();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Value("${openai.url.base}")
     private String API_BASE_URL;
@@ -19,11 +22,20 @@ public class ChatGptUtil {
     private String API_KEY;
 
     public CompletableFuture<String> createChatCompletion(ChatCompletionRequest requestBody, String API_URL) {
+        String jsonBody = null;
+        try {
+            jsonBody = mapper.writeValueAsString(requestBody);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        System.out.println(jsonBody);
+
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(API_BASE_URL + API_URL))
                 .header("Content-Type", "application/json")
                 .header("Authorization", "Bearer " + API_KEY)
-                .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
                 .build();
 
         return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())

--- a/src/main/java/adhd/diary/chatgpt/util/ChatGptUtil.java
+++ b/src/main/java/adhd/diary/chatgpt/util/ChatGptUtil.java
@@ -1,0 +1,33 @@
+package adhd.diary.chatgpt.util;
+
+import adhd.diary.chatgpt.dto.ChatCompletionRequest;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Value;
+
+public class ChatGptUtil {
+
+    private final HttpClient client = HttpClient.newBuilder().build();
+
+    @Value("${openai.url.base}")
+    private String API_BASE_URL;
+
+    @Value("${chatgpt.api-key}")
+    private String API_KEY;
+
+    public CompletableFuture<String> createChatCompletion(ChatCompletionRequest requestBody, String API_URL) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_BASE_URL + API_URL))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + API_KEY)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                .build();
+
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(HttpResponse::body)
+                .exceptionally(e -> "Error: " + e.getMessage());
+    }
+}

--- a/src/main/java/adhd/diary/diary/common/BaseTimeEntity.java
+++ b/src/main/java/adhd/diary/diary/common/BaseTimeEntity.java
@@ -23,5 +23,4 @@ public class BaseTimeEntity {
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
     }
-
 }

--- a/src/main/java/adhd/diary/diary/controller/DiaryController.java
+++ b/src/main/java/adhd/diary/diary/controller/DiaryController.java
@@ -1,6 +1,6 @@
 package adhd.diary.diary.controller;
 
-import adhd.diary.diary.application.DiaryService;
+import adhd.diary.diary.service.DiaryService;
 import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryResponse;
 import java.net.URI;
@@ -45,5 +45,4 @@ public class DiaryController {
         DiaryResponse diaryResponse = diaryService.updateById(id, request);
         return ResponseEntity.ok(diaryResponse);
     }
-
 }

--- a/src/main/java/adhd/diary/diary/domain/Diary.java
+++ b/src/main/java/adhd/diary/diary/domain/Diary.java
@@ -12,14 +12,14 @@ public class Diary extends BaseTimeEntity {
 
     @Column(length = 1000)
     private String content;
+
     private Emotion emotion;
 
     @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public Diary(String content,
-                 Emotion emotion){
+    public Diary(String content, Emotion emotion){
         this.content = content;
         this.emotion = emotion;
     }
@@ -45,5 +45,4 @@ public class Diary extends BaseTimeEntity {
     public Emotion getEmotion() {
         return emotion;
     }
-
 }

--- a/src/main/java/adhd/diary/diary/domain/Emotion.java
+++ b/src/main/java/adhd/diary/diary/domain/Emotion.java
@@ -24,5 +24,4 @@ public enum Emotion {
     public String getType() {
         return type;
     }
-
 }

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -1,4 +1,4 @@
-package adhd.diary.diary.application;
+package adhd.diary.diary.service;
 
 import adhd.diary.diary.domain.Diary;
 import adhd.diary.diary.domain.DiaryRepository;
@@ -40,5 +40,4 @@ public class DiaryService {
 
         return new DiaryResponse(diary);
     }
-
 }

--- a/src/main/java/adhd/diary/global/config/ChatGptConfig.java
+++ b/src/main/java/adhd/diary/global/config/ChatGptConfig.java
@@ -1,0 +1,14 @@
+package adhd.diary.global.config;
+
+import adhd.diary.chatgpt.util.ChatGptUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatGptConfig {
+
+    @Bean
+    public ChatGptUtil chatGptUtil() {
+        return new ChatGptUtil();
+    }
+}

--- a/src/main/java/adhd/diary/global/config/JpaConfig.java
+++ b/src/main/java/adhd/diary/global/config/JpaConfig.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaConfiguration {
+public class JpaConfig {
 }


### PR DESCRIPTION
## 개요

- 사용자가 일기를 작성하면 일기 내용을 통해 감정을 분석한다.

### PR 타입
- 기능 추가

### 변경 사항
- GPT API를 사용하기 위한 통신 구현
- 일기 내용 분석을 위한 API 엔드포인트 구현
- 일기 내용 분석을 위한 자체 프롬프트 구현
- 비동기 통신을 위한 HttpClient 사용

### 테스트 결과
- [X] GPT API 통신 진행
- [X] 프롬프트를 통한 임시 일기 내용 감정 분석 진행
- [ ] 비동기 통신 구현이 적절하게 되었는지 수행

