### PR TITLE
feat: 예외처리 작성

### DIFF
--- a/src/main/java/adhd/diary/auth/controller/AuthApiController.java
+++ b/src/main/java/adhd/diary/auth/controller/AuthApiController.java
@@ -2,6 +2,9 @@ package adhd.diary.auth.controller;
 
 import adhd.diary.auth.service.AuthService;
 import adhd.diary.member.dto.CompleteRegistrationRequest;
+import adhd.diary.member.dto.MemberResponse;
+import adhd.diary.response.ApiResponse;
+import adhd.diary.response.ResponseCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,10 +21,10 @@ public class AuthApiController {
     }
 
     @PostMapping("/complete-registration")
-    public ResponseEntity<?> completeRegistration (@RequestBody CompleteRegistrationRequest completeRegistrationRequest, Principal principal) {
+    public ApiResponse<?> completeRegistration (@RequestBody CompleteRegistrationRequest completeRegistrationRequest, Principal principal) {
 
-        memberService.completeRegistration(completeRegistrationRequest, principal.getName());
+        MemberResponse memberResponse = memberService.completeRegistration(completeRegistrationRequest, principal.getName());
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.success(ResponseCode.USER_CREATE_SUCCESS, memberResponse);
     }
 }

--- a/src/main/java/adhd/diary/auth/service/AuthService.java
+++ b/src/main/java/adhd/diary/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import adhd.diary.auth.jwt.JwtService;
 import adhd.diary.member.domain.Member;
 import adhd.diary.member.domain.MemberRepository;
 import adhd.diary.member.dto.CompleteRegistrationRequest;
+import adhd.diary.member.dto.MemberResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +36,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void completeRegistration(CompleteRegistrationRequest registrationRequest, String email) {
+    public MemberResponse completeRegistration(CompleteRegistrationRequest registrationRequest, String email) {
 
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
@@ -43,7 +44,8 @@ public class AuthService {
         updateNickname(member.getId(), registrationRequest.getNickname());
         updateBirthDay(member.getId(), registrationRequest.getBirthDay());
 
-        memberRepository.saveAndFlush(member);
-    }
+        Member completedMember = memberRepository.saveAndFlush(member);
 
+        return new MemberResponse(completedMember.getEmail(), completedMember.getNickname(), completedMember.getBirthDay(), completedMember.getRole(), completedMember.getSocialId(), completedMember.getSocialProvider());
+    }
 }

--- a/src/main/java/adhd/diary/diary/controller/DiaryController.java
+++ b/src/main/java/adhd/diary/diary/controller/DiaryController.java
@@ -4,6 +4,9 @@ import adhd.diary.diary.service.DiaryService;
 import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryResponse;
 import java.net.URI;
+
+import adhd.diary.response.ApiResponse;
+import adhd.diary.response.ResponseCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,26 +26,26 @@ public class DiaryController {
     }
 
     @PostMapping("/diary")
-    public ResponseEntity<DiaryResponse> create(@RequestBody DiaryRequest request) {
+    public ApiResponse<DiaryResponse> create(@RequestBody DiaryRequest request) {
         DiaryResponse diaryResponse = diaryService.save(request);
-        return ResponseEntity.created(URI.create("/diary")).body(diaryResponse);
+        return ApiResponse.success(ResponseCode.DIARY_CREATE_SUCCESS, diaryResponse);
     }
 
     @GetMapping("/diary/{id}")
-    public ResponseEntity<DiaryResponse> diary(@PathVariable Long id) {
+    public ApiResponse<DiaryResponse> diary(@PathVariable Long id) {
         DiaryResponse diaryResponse = diaryService.findById(id);
-        return ResponseEntity.ok(diaryResponse);
+        return ApiResponse.success(ResponseCode.DIARY_READ_BY_ID_SUCCESS, diaryResponse);
     }
 
     @DeleteMapping("/diary/{id}")
-    public ResponseEntity<Void> remove(@PathVariable Long id) {
+    public ApiResponse<Void> remove(@PathVariable Long id) {
         diaryService.deleteById(id);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.success(ResponseCode.DIARY_DELETE_SUCCESS);
     }
 
     @PutMapping("/diary/{id}")
-    public ResponseEntity<DiaryResponse> update(@PathVariable Long id, @RequestBody DiaryRequest request) {
+    public ApiResponse<DiaryResponse> update(@PathVariable Long id, @RequestBody DiaryRequest request) {
         DiaryResponse diaryResponse = diaryService.updateById(id, request);
-        return ResponseEntity.ok(diaryResponse);
+        return ApiResponse.success(ResponseCode.DIARY_UPDATE_SUCCESS);
     }
 }

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -4,7 +4,10 @@ import adhd.diary.diary.domain.Diary;
 import adhd.diary.diary.domain.DiaryRepository;
 import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryResponse;
+import adhd.diary.exception.DiaryException;
+import adhd.diary.response.ResponseCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class DiaryService {
@@ -15,24 +18,30 @@ public class DiaryService {
         this.diaryRepository = diaryRepository;
     }
 
+    @Transactional
     public DiaryResponse save(DiaryRequest request) {
         Diary diary = diaryRepository.save(request.toEntity());
         return new DiaryResponse(diary);
     }
 
+    @Transactional
     public DiaryResponse findById(Long id) {
         Diary diary = diaryRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("일기장 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new DiaryException(ResponseCode.DIARY_NOT_FOUND));
         return new DiaryResponse(diary);
     }
 
+    @Transactional
     public void deleteById(Long id) {
-        diaryRepository.deleteById(id);
+        Diary diary = diaryRepository.findById(id)
+                .orElseThrow(() -> new DiaryException(ResponseCode.DIARY_NOT_FOUND));
+        diaryRepository.delete(diary);
     }
 
+    @Transactional
     public DiaryResponse updateById(Long id, DiaryRequest request) {
         Diary existingDiary = diaryRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("일기장 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new DiaryException(ResponseCode.DIARY_NOT_FOUND));
         existingDiary.setContent(request.content());
         existingDiary.setEmotion(request.emotion());
 

--- a/src/main/java/adhd/diary/exception/BaseException.java
+++ b/src/main/java/adhd/diary/exception/BaseException.java
@@ -1,0 +1,16 @@
+package adhd.diary.exception;
+
+import adhd.diary.response.ResponseCode;
+
+public class BaseException extends IllegalArgumentException {
+
+    private ResponseCode responseCode;
+
+    public BaseException(ResponseCode responseCode) {
+    }
+
+    @Override
+    public String getMessage() {
+        return responseCode.getMessage();
+    }
+}

--- a/src/main/java/adhd/diary/exception/DiaryException.java
+++ b/src/main/java/adhd/diary/exception/DiaryException.java
@@ -1,0 +1,10 @@
+package adhd.diary.exception;
+
+import adhd.diary.response.ResponseCode;
+
+public class DiaryException extends BaseException{
+
+    public DiaryException(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/adhd/diary/exception/MemberException.java
+++ b/src/main/java/adhd/diary/exception/MemberException.java
@@ -1,0 +1,10 @@
+package adhd.diary.exception;
+
+import adhd.diary.response.ResponseCode;
+
+public class MemberException extends BaseException{
+
+    public MemberException(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/adhd/diary/member/domain/Member.java
+++ b/src/main/java/adhd/diary/member/domain/Member.java
@@ -67,6 +67,22 @@ public class Member extends BaseTimeEntity {
         return refreshToken;
     }
 
+    public String getNickname() {
+        return nickname;
+    }
+
+    public SocialProvider getSocialProvider() {
+        return socialProvider;
+    }
+
+    public LocalDate getBirthDay() {
+        return birthDay;
+    }
+
+    public List<Diary> getDiaryList() {
+        return diaryList;
+    }
+
     public static class Builder {
 
         private Role role;

--- a/src/main/java/adhd/diary/member/dto/MemberResponse.java
+++ b/src/main/java/adhd/diary/member/dto/MemberResponse.java
@@ -1,0 +1,25 @@
+package adhd.diary.member.dto;
+
+import adhd.diary.member.domain.Role;
+import adhd.diary.member.domain.SocialProvider;
+
+import java.time.LocalDate;
+
+public class MemberResponse {
+
+    private String email;
+    private String nickname;
+    private LocalDate birthDay;
+    private Role role;
+    private String socialId;
+    private SocialProvider socialProvider;
+
+    public MemberResponse(String email, String nickname, LocalDate birthDay, Role role, String socialId, SocialProvider socialProvider) {
+        this.email = email;
+        this.nickname = nickname;
+        this.birthDay = birthDay;
+        this.role = role;
+        this.socialId = socialId;
+        this.socialProvider = socialProvider;
+    }
+}

--- a/src/main/java/adhd/diary/response/ApiBody.java
+++ b/src/main/java/adhd/diary/response/ApiBody.java
@@ -1,0 +1,10 @@
+package adhd.diary.response;
+
+public class ApiBody <T> {
+
+    private T data;
+
+    public ApiBody(T data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/adhd/diary/response/ApiHeader.java
+++ b/src/main/java/adhd/diary/response/ApiHeader.java
@@ -1,0 +1,14 @@
+package adhd.diary.response;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiHeader {
+
+    private HttpStatus status;
+    private String message;
+
+    public ApiHeader(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/adhd/diary/response/ApiResponse.java
+++ b/src/main/java/adhd/diary/response/ApiResponse.java
@@ -1,0 +1,32 @@
+package adhd.diary.response;
+
+public class ApiResponse <T> {
+
+    private ApiHeader header;
+    private ApiBody <T> body;
+
+    public ApiResponse(ApiHeader header){
+        this.header = header;
+    }
+
+    public ApiResponse(ApiHeader header, ApiBody body){
+        this.header = header;
+        this.body = body;
+    }
+
+    public static <T> ApiResponse<T> success(ResponseCode responseCode, T data) {
+        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatus(), responseCode.getMessage()), new ApiBody<>(data));
+    }
+
+    public static <T> ApiResponse<T> success(ResponseCode responseCode) {
+        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatus(), responseCode.getMessage()));
+    }
+
+    public static <T> ApiResponse<T> fail(ResponseCode responseCode) {
+        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatus(), responseCode.getMessage()));
+    }
+
+    public static <T> ApiResponse<T> fail(ResponseCode responseCode, String message) {
+        return new ApiResponse<T>(new ApiHeader(responseCode.getHttpStatus(), responseCode.getMessage()), new ApiBody(message));
+    }
+}

--- a/src/main/java/adhd/diary/response/ResponseCode.java
+++ b/src/main/java/adhd/diary/response/ResponseCode.java
@@ -1,0 +1,60 @@
+package adhd.diary.response;
+
+import org.springframework.http.HttpStatus;
+
+public enum ResponseCode {
+
+    //400 Bad Request
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    //403 Forbidden
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+
+    //405 Method Not Allowed
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메소드입니다."),
+
+    //500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생하였습니다."),
+
+    /**
+     * user response
+     */
+    //404 Not Found
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다,"),
+
+    //200 OK
+    USER_READ_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
+    USER_LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
+
+    //201 Created
+    USER_CREATE_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
+
+    /**
+     * diary response
+     */
+    //404 Not Found
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "일기를 찾을 수 없습니다,"),
+
+    //200 OK
+    DIARY_READ_ALL_SUCCESS(HttpStatus.OK, "일기 전체 조회 성공"),
+    DIARY_READ_BY_ID_SUCCESS(HttpStatus.OK, "일기 조회 성공"),
+    DIARY_UPDATE_SUCCESS(HttpStatus.OK, "일기 수정 성공"),
+    DIARY_DELETE_SUCCESS(HttpStatus.OK, "일기 삭제 성공"),
+
+    //201 Created
+    DIARY_CREATE_SUCCESS(HttpStatus.CREATED, "일기 생성 성공");
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    ResponseCode(HttpStatus httpStatus, String s) {
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`exception` -> `main`

### 변경 사항
1. `AuthApiController` 변경:
- `completeRegistration` 메서드의 반환 타입을 `ResponseEntity<?>`에서 `ApiResponse<?>`로 변경
- 회원 가입 완료 후, `MemberResponse`를 포함한 응답으로 변경

2. `AuthService` 변경:
- `completeRegistration` 메서드의 반환 타입을 `void`에서 `MemberResponse`로 변경
- 회원 가입 후, `MemberResponse` 객체를 반환하도록 수정

3. `Diary` 컨트롤러 변경:
- 엔드포인트 응답 타입을 `ResponseEntity<DiaryResponse>`에서 `ApiResponse<DiaryResponse>`로 변경
- 각 메서드에서 성공 응답에 `ApiResponse`를 사용하도록 수정

4. Diary 서비스 변경:
- 예외 처리: `IllegalArgumentException` 대신 `DiaryException`을 던지도록 수정
- `deleteById` 메서드에서 두 번 삭제를 수행하던 부분을 수정
- `updateById` 메서드에서 일기장 정보를 찾을 수 없는 경우에 대한 예외 처리 추가

5. 예외 처리 개선
- `BaseException`, `DiaryException`, `MemberException` 클래스를 추가하여 예외 처리 개선.

6. 회원 정보 응답
- MemberResponse 클래스 추가: 회원 정보를 응답으로 포함할 수 있도록 함

7. 응답 처리
- ApiResponse 및 ApiBody, ApiHeader 클래스를 추가하여 표준화된 응답 처리
- ResponseCode 열거형 추가: 다양한 응답 상태 코드 및 메시지 정의

### 테스트 결과
1. 회원 가입 완료
- `completeRegistration` 메서드 호출 시, `MemberResponse` 객체를 포함한 `ApiResponse`가 정상적으로 반환되는지 확인
- 회원 가입이 성공적으로 처리되고, 응답으로 회원 정보가 포함되는지 검증

2. Diary 엔드포인트
- Diary 관련 엔드포인트에서 응답 타입이 `ApiResponse<DiaryResponse>`로 변경된 후, 모든 메서드가 예상대로 `ApiResponse`를 사용하여 성공적인 응답을 반환하는지 확인
- `deleteById` 메서드의 경우, 중복 삭제 문제가 해결되었으며, `updateById` 메서드에서 일기장 정보가 없을 경우 적절한 `DiaryException`이 발생하는지 검증했습니다.

3. 예외 처리
- `BaseException`, `DiaryException`, `MemberException` 클래스 추가 후, 각 예외가 적절하게 처리되는지 확인
- 예외 발생 시, 명확한 에러 메시지와 상태 코드가 반환되는지 확인

4. 회원 정보 응답
- `MemberResponse` 클래스가 추가된 후, 회원 정보가 올바르게 응답으로 포함되는지 확인

5. 응답 처리
- `ApiResponse`, `ApiBody`, `ApiHeader` 클래스 및 `ResponseCode` 열거형을 도입한 후, 표준화된 응답 처리 기능이 제대로 동작하는지 확인
- 응답 코드와 메시지가 정확하게 반환되는지 확인