### PR TITLE
feat: refresh token 으로 access, refresh token 재발급

### DIFF
--- a/src/main/java/adhd/diary/auth/controller/AuthController.java
+++ b/src/main/java/adhd/diary/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package adhd.diary.auth.controller;
+
+import adhd.diary.auth.dto.response.TokenResponse;
+import adhd.diary.auth.exception.token.TokenNotFoundException;
+import adhd.diary.auth.jwt.JwtService;
+import adhd.diary.response.ApiResponse;
+import adhd.diary.response.ResponseCode;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    private final JwtService jwtService;
+
+    public AuthController(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/api/auth/token/refresh")
+    public ApiResponse<?> refreshAccessToken(HttpServletResponse response, @RequestHeader("RefreshToken") String refreshToken) {
+        try {
+            TokenResponse tokenResponse = jwtService.refreshTokens(refreshToken);
+            jwtService.sendAccessAndRefreshToken(response, tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+
+            return ApiResponse.success(ResponseCode.JWT_REFRESH_SUCCESS, tokenResponse);
+        } catch (TokenNotFoundException e) {
+            return ApiResponse.fail(ResponseCode.JWT_REFRESH_TOKEN_EXPIRED, e.getMessage());
+        } catch (Exception e) {
+            return ApiResponse.fail(ResponseCode.UNEXPECTED_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/adhd/diary/response/ResponseCode.java
+++ b/src/main/java/adhd/diary/response/ResponseCode.java
@@ -56,6 +56,8 @@ public enum ResponseCode {
     UNKNOWN_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "알 수 없는 토큰 유형입니다."),
     TOKEN_VALIDATION_FAILED(HttpStatus.UNAUTHORIZED, "토큰 검증에 실패했습니다."),
     UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다."),
+    JWT_REFRESH_SUCCESS(HttpStatus.OK, "JWT 토큰 재발급 성공"),
+
 
     // OAuth2 Token retrieval errors
     KAKAO_TOKEN_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "카카오 토큰 가져오기에 실패하였습니다."),


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refreshToken` -> `main`

### 변경 사항
- refreshToken을 이용해 새로운 accessToken과 refreshToken을 발급하는 기능을 추가
  - `/api/auth/token/refresh` 엔드포인트를 통해 리프레시 토큰을 기반으로 새로운 액세스 토큰과 리프레시 토큰을 생성
  - 응답 헤더와 본문에 새로운 토큰을 포함
  - 토큰 검증 및 갱신 로직을 JwtService 클래스에 구현
 
### 테스트 결과
- **성공적인 토큰 갱신**: 리프레시 토큰을 제공하면 새로운 액세스 토큰과 리프레시 토큰이 발급됨
- **유효하지 않은 리프레시 토큰 처리**: 만료되거나 유효하지 않은 리프레시 토큰에 대해 적절한 오류 응답이 반환됨
- **예외 처리**: 토큰 검증 과정에서 발생할 수 있는 예외를 처리하여 적절한 오류 메시지와 상태 코드가 반환됨