### PR TITLE
feat: loginform 제거

### DIFF
--- a/src/main/java/adhd/diary/global/config/SecurityConfig.java
+++ b/src/main/java/adhd/diary/global/config/SecurityConfig.java
@@ -8,11 +8,13 @@ import adhd.diary.auth.service.CustomOAuth2UserService;
 import adhd.diary.member.domain.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -54,6 +56,10 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(
                             SessionCreationPolicy.STATELESS
                 ))
+                .exceptionHandling(httpSecurityExceptionHandlingConfigurer ->
+                        httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(
+                                new HttpStatusEntryPoint(HttpStatus.NOT_FOUND)
+                        ))
                 .authorizeHttpRequests(authorizationRequest ->
                         authorizationRequest.requestMatchers(
                                 AntPathRequestMatcher.antMatcher("/favicon.ico")


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`cors` -> `main`

### 변경 사항
1. SecurityConfig 변경:
- OAuth2 클라이언트에서 제공하는 기본 로그인 폼을 제거하고, 인증 실패 시 HttpStatus.NOT_FOUND 응답을 반환하도록 설정