### PR TITLE
feat: ChatGpt 커스텀 예외처리 진행

### DIFF
--- a/src/main/java/adhd/diary/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/adhd/diary/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,34 @@
+package adhd.diary.auth.exception;
+
+import adhd.diary.response.ErrorResponse;
+import java.time.LocalDateTime;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+@ControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(KakaoTokenRequestFailedException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoTokenRequestFailedException(KakaoTokenRequestFailedException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().name(),
+                exception.getResponseCode().getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(KakaoMemberRequestFailedException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoMemberRequestFailedException(KakaoMemberRequestFailedException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().name(),
+                exception.getResponseCode().getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+}

--- a/src/main/java/adhd/diary/auth/exception/KakaoMemberRequestFailedException.java
+++ b/src/main/java/adhd/diary/auth/exception/KakaoMemberRequestFailedException.java
@@ -1,0 +1,11 @@
+package adhd.diary.auth.exception;
+
+import adhd.diary.global.exception.BaseException;
+import adhd.diary.response.ResponseCode;
+
+public class KakaoMemberRequestFailedException extends BaseException {
+
+    public KakaoMemberRequestFailedException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/adhd/diary/auth/exception/KakaoTokenRequestFailedException.java
+++ b/src/main/java/adhd/diary/auth/exception/KakaoTokenRequestFailedException.java
@@ -1,0 +1,11 @@
+package adhd.diary.auth.exception;
+
+import adhd.diary.global.exception.BaseException;
+import adhd.diary.response.ResponseCode;
+
+public class KakaoTokenRequestFailedException extends BaseException {
+
+    public KakaoTokenRequestFailedException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
@@ -18,16 +18,26 @@ public class ChatGptController {
 
     private final ChatGptService chatGptService;
 
-    @Value("${chatgpt.analyze}")
+    @Value("${chatgpt.emotion-analyze}")
     private String analyzeSentence;
+
+    @Value("${chatgpt.recommend-song}")
+    private String recommendSongSentence;
 
     public ChatGptController(ChatGptService chatGptService) {
         this.chatGptService = chatGptService;
     }
 
     @PostMapping("/chatgpt/diary-analyze")
-    public CompletableFuture<ResponseEntity<String>> createChatCompletion(@RequestParam String diaryContents) {
-        return chatGptService.analyzeDiaryContents(List.of(new ChatMessage(diaryContents + analyzeSentence)))
+    public CompletableFuture<ResponseEntity<String>> getAnalyzedDiary(@RequestParam String diaryContents) {
+        return chatGptService.analyzeDiary(List.of(new ChatMessage(diaryContents + analyzeSentence)))
+                .thenApply(ResponseEntity::ok)
+                .exceptionally(e -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error : " + e.getMessage()));
+    }
+
+    @PostMapping("/chatgpt/recommend-song")
+    public CompletableFuture<ResponseEntity<String>> getRecommendSong(@RequestParam String diaryContents) {
+        return chatGptService.recommendSong(List.of(new ChatMessage(diaryContents + recommendSongSentence)))
                 .thenApply(ResponseEntity::ok)
                 .exceptionally(e -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error : " + e.getMessage()));
     }

--- a/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
+++ b/src/main/java/adhd/diary/chatgpt/dto/ChatCompletionRequest.java
@@ -6,17 +6,16 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class ChatCompletionRequest {
 
-    @Value("${chatgpt.model}")
-    private String model = "gpt-3.5-turbo-0125";
-
+    private String model;
     private List<ChatMessage> messages;
 
     @JsonProperty("max_tokens")
-    @Value("${chatgpt.max-tokens}")
     private Integer maxTokens;
 
-    public ChatCompletionRequest(List<ChatMessage> messages) {
+    public ChatCompletionRequest(String model, List<ChatMessage> messages, Integer maxTokens) {
+        this.model = model;
         this.messages = messages;
+        this.maxTokens = maxTokens;
     }
 
     public String getModel() {

--- a/src/main/java/adhd/diary/chatgpt/exception/ChatGptDeserializationException.java
+++ b/src/main/java/adhd/diary/chatgpt/exception/ChatGptDeserializationException.java
@@ -1,0 +1,11 @@
+package adhd.diary.chatgpt.exception;
+
+import adhd.diary.global.exception.BaseException;
+import adhd.diary.response.ResponseCode;
+
+public class ChatGptDeserializationException extends BaseException {
+
+    public ChatGptDeserializationException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/exception/ChatGptExceptionHandler.java
+++ b/src/main/java/adhd/diary/chatgpt/exception/ChatGptExceptionHandler.java
@@ -1,0 +1,56 @@
+package adhd.diary.chatgpt.exception;
+
+import adhd.diary.response.ErrorResponse;
+import java.time.LocalDateTime;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+@ControllerAdvice
+public class ChatGptExceptionHandler {
+
+    @ExceptionHandler(ChatGptJsonParsingException.class)
+    public ResponseEntity<ErrorResponse> handleChatGptJsonParsingException(ChatGptJsonParsingException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().name(),
+                exception.getResponseCode().getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(ChatGptRequestParsingException.class)
+    public ResponseEntity<ErrorResponse> handleChatGptRequestParsingException(ChatGptRequestParsingException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().name(),
+                exception.getResponseCode().getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(ChatGptRetrievalException.class)
+    public ResponseEntity<ErrorResponse> handleChatGptRetrievalException(ChatGptRetrievalException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().name(),
+                exception.getResponseCode().getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(ChatGptDeserializationException.class)
+    public ResponseEntity<ErrorResponse> handleChatGptDeserializationException(ChatGptDeserializationException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().name(),
+                exception.getResponseCode().getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/exception/ChatGptJsonParsingException.java
+++ b/src/main/java/adhd/diary/chatgpt/exception/ChatGptJsonParsingException.java
@@ -1,0 +1,11 @@
+package adhd.diary.chatgpt.exception;
+
+import adhd.diary.global.exception.BaseException;
+import adhd.diary.response.ResponseCode;
+
+public class ChatGptJsonParsingException extends BaseException {
+
+    public ChatGptJsonParsingException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/exception/ChatGptRequestParsingException.java
+++ b/src/main/java/adhd/diary/chatgpt/exception/ChatGptRequestParsingException.java
@@ -1,0 +1,11 @@
+package adhd.diary.chatgpt.exception;
+
+import adhd.diary.global.exception.BaseException;
+import adhd.diary.response.ResponseCode;
+
+public class ChatGptRequestParsingException extends BaseException {
+
+    public ChatGptRequestParsingException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/exception/ChatGptRetrievalException.java
+++ b/src/main/java/adhd/diary/chatgpt/exception/ChatGptRetrievalException.java
@@ -1,0 +1,11 @@
+package adhd.diary.chatgpt.exception;
+
+import adhd.diary.global.exception.BaseException;
+import adhd.diary.response.ResponseCode;
+
+public class ChatGptRetrievalException extends BaseException {
+
+    public ChatGptRetrievalException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/adhd/diary/chatgpt/service/ChatGptService.java
+++ b/src/main/java/adhd/diary/chatgpt/service/ChatGptService.java
@@ -11,8 +11,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class ChatGptService {
 
+    @Value("${chatgpt.model}")
+    private String model;
+
     @Value("${openai.url.prompt}")
     private String API_URL;
+
+    @Value("${chatgpt.max-tokens}")
+    private Integer maxTokens;
 
     private final ChatGptUtil chatGptUtil;
 
@@ -20,11 +26,15 @@ public class ChatGptService {
         this.chatGptUtil = chatGptUtil;
     }
 
-    public CompletableFuture<String> analyzeDiaryContents(List<ChatMessage> messages) {
+    public CompletableFuture<String> analyzeDiary(List<ChatMessage> messages) {
+        return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
+    }
+
+    public CompletableFuture<String> recommendSong(List<ChatMessage> messages) {
         return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
     }
 
     public ChatCompletionRequest toChatCompletionRequest(List<ChatMessage> messages) {
-        return new ChatCompletionRequest(messages);
+        return new ChatCompletionRequest(model, messages, maxTokens);
     }
 }

--- a/src/main/java/adhd/diary/response/ResponseCode.java
+++ b/src/main/java/adhd/diary/response/ResponseCode.java
@@ -4,51 +4,35 @@ import org.springframework.http.HttpStatus;
 
 public enum ResponseCode {
 
-    // 400 Bad Request
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-
-    // 403 Forbidden
-    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-
-    // 405 Method Not Allowed
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메소드입니다."),
-
-    // 500 Internal Server Error
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생하였습니다."),
-
     /**
      * User response
      */
-    // 404 Not Found
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다,"),
 
-    // 200 OK
     MEMBER_READ_SUCCESS(HttpStatus.OK, "사용자 정보 조회 성공"),
     KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공"),
     NAVER_LOGIN_SUCCESS(HttpStatus.OK, "네이버 로그인 성공"),
     GOOGLE_LOGIN_SUCCESS(HttpStatus.OK, "구글 로그인 성공"),
     NICKNAME_UPDATE_SUCCESS(HttpStatus.OK, "닉네임 수정 성공"),
 
-    // 201 Created
     MEMBER_CREATE_SUCCESS(HttpStatus.CREATED, "회원가입 성공"),
 
     /**
      * Diary response
      */
-    // 404 Not Found
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "일기를 찾을 수 없습니다."),
     DIARY_FORBIDDEN(HttpStatus.FORBIDDEN, "일기장에 접근할 권한이 없습니다."),
 
-    // 200 OK
     DIARY_READ_ALL_SUCCESS(HttpStatus.OK, "일기 전체 조회 성공"),
     DIARY_READ_BY_ID_SUCCESS(HttpStatus.OK, "일기 조회 성공"),
     DIARY_UPDATE_SUCCESS(HttpStatus.OK, "일기 수정 성공"),
     DIARY_DELETE_SUCCESS(HttpStatus.OK, "일기 삭제 성공"),
 
-    // 201 Created
     DIARY_CREATE_SUCCESS(HttpStatus.CREATED, "일기 생성 성공"),
 
-    // JWT Token errors
+    /**
+     * JWT Token errors
+     */
     JWT_ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "자체 JWT ACCESS 토큰이 만료되었습니다."),
     JWT_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "자체 JWT REFRESH 토큰이 만료되었습니다."),
 
@@ -58,16 +42,28 @@ public enum ResponseCode {
     UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다."),
     JWT_REFRESH_SUCCESS(HttpStatus.OK, "JWT 토큰 재발급 성공"),
 
-
-    // OAuth2 Token retrieval errors
+    /**
+     * OAuth2 Token retrieval errors
+     */
     KAKAO_TOKEN_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "카카오 토큰 가져오기에 실패하였습니다."),
     GOOGLE_TOKEN_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "구글 토큰 가져오기에 실패하였습니다."),
     NAVER_TOKEN_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "네이버 토큰 가져오기에 실패하였습니다."),
 
-    // OAuth2 User info retrieval errors
+    /**
+     * OAuth2 User info retrieval errors
+     */
     KAKAO_USER_INFO_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "카카오 사용자 정보를 가져오는데 실패하였습니다."),
     GOOGLE_USER_INFO_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "구글 사용자 정보를 가져오는데 실패하였습니다."),
-    NAVER_USER_INFO_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "네이버 사용자 정보를 가져오는데 실패하였습니다.");
+    NAVER_USER_INFO_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "네이버 사용자 정보를 가져오는데 실패하였습니다."),
+
+    /**
+     * ChatGPT response
+     */
+    CHATGPT_REQUEST_PARSING_FAILED(HttpStatus.BAD_REQUEST, "올바른 일기장 내용을 요청해주세요."),
+    CHATGPT_JSON_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 파싱에 실패했습니다."),
+    CHATGPT_RETRIEVAL_FAILED(HttpStatus.UNAUTHORIZED, "일기장 분석 요청에 실패했습니다."),
+
+    CHATGPT_DESERIALIZATION_FAILED(HttpStatus.BAD_REQUEST, "객체 변환에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 개요

- ChatGpt 예외 발생 시 예외 처리를 지정하지 않아 문제가 발생

### PR 타입

- 기능 추가

### 변경 사항

- ChatGpt Util의 각 메서드에 맞는 커스텀 예외 구현
- 커스텀 예외에 맞는 ResponseCode 구현

### 테스트 결과

- [X] ChatGpt Api 요청할 때 예외 발생 시 예외 처리