### PR TITLE
feat: 달력 작년 날짜 조회

### DIFF
--- a/src/main/java/adhd/diary/diary/controller/DiaryController.java
+++ b/src/main/java/adhd/diary/diary/controller/DiaryController.java
@@ -38,6 +38,12 @@ public class DiaryController {
         return ApiResponse.success(ResponseCode.DIARY_READ_BY_ID_SUCCESS, diaryDateResponse);
     }
 
+    @GetMapping("/diary/last-year")
+    public ApiResponse<DiaryResponse> getDiaryFromLastYear(@RequestParam String date) {
+        DiaryResponse lastYearDiary = diaryService.findLastYearDiary(date);
+        return ApiResponse.success(ResponseCode.DIARY_READ_BY_YEAR_SUCCESS, lastYearDiary);
+    }
+
     @GetMapping("/diarys")
     public ApiResponse<List<DiaryResponse>> diaryAll() {
         List<DiaryResponse> diaryResponses = diaryService.findAll();

--- a/src/main/java/adhd/diary/diary/domain/DiaryRepository.java
+++ b/src/main/java/adhd/diary/diary/domain/DiaryRepository.java
@@ -1,10 +1,16 @@
 package adhd.diary.diary.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<List<Diary>> findByMemberId(Long memberId);
+
+    @Query("SELECT d FROM Diary d WHERE d.date = :targetDate")
+    Optional<Diary> findLastYearByDate(@Param("targetDate") LocalDate targetDate);
 }

--- a/src/main/java/adhd/diary/diary/dto/response/DiaryDateResponse.java
+++ b/src/main/java/adhd/diary/diary/dto/response/DiaryDateResponse.java
@@ -5,11 +5,13 @@ import adhd.diary.diary.domain.Emotion;
 import java.time.LocalDate;
 
 public record DiaryDateResponse(Long id,
+                                String content,
                                 Emotion emotion,
                                 LocalDate date) {
     public DiaryDateResponse(Diary diary) {
         this(
                 diary.getId(),
+                diary.getContent(),
                 diary.getEmotion(),
                 diary.getDate()
         );

--- a/src/main/java/adhd/diary/diary/exception/DiaryExceptionHandler.java
+++ b/src/main/java/adhd/diary/diary/exception/DiaryExceptionHandler.java
@@ -33,7 +33,7 @@ public class DiaryExceptionHandler {
     }
 
     @ExceptionHandler(DiaryLocalDateConverterException.class)
-    public ResponseEntity<ErrorResponse> handleDiaryLocalDateConverterException(DiaryForbiddenException exception, WebRequest request) {
+    public ResponseEntity<ErrorResponse> handleDiaryLocalDateConverterException(DiaryLocalDateConverterException exception, WebRequest request) {
         ErrorResponse errorResponse = new ErrorResponse(
                 LocalDateTime.now(),
                 exception.getResponseCode().name(),

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -73,7 +73,7 @@ public class DiaryService {
         return diaries.stream().map(DiaryDateResponse::new).toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public DiaryResponse findLastYearDiary(String date) {
         Diary diary = diaryRepository.findLastYearByDate(convertLastDate(date))
                 .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -6,11 +6,15 @@ import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryDateResponse;
 import adhd.diary.diary.dto.response.DiaryResponse;
 import adhd.diary.diary.exception.DiaryForbiddenException;
+import adhd.diary.diary.exception.DiaryLocalDateConverterException;
 import adhd.diary.diary.exception.DiaryNotFoundException;
 import adhd.diary.member.domain.Member;
 import adhd.diary.member.domain.MemberRepository;
 import adhd.diary.member.exception.MemberNotFoundException;
 import adhd.diary.response.ResponseCode;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -70,6 +74,13 @@ public class DiaryService {
     }
 
     @Transactional
+    public DiaryResponse findLastYearDiary(String date) {
+        Diary diary = diaryRepository.findLastYearByDate(convertLastDate(date))
+                .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));
+        return new DiaryResponse(diary);
+    }
+
+    @Transactional
     public void deleteById(Long id) {
         Diary diary = diaryRepository.findById(id)
                 .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));
@@ -104,5 +115,15 @@ public class DiaryService {
     private static String getAuthenticationMemberEmail() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication.getName();
+    }
+
+    public LocalDate convertLastDate(String date) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        try {
+            LocalDate lastDate = LocalDate.parse(date, formatter);
+            return lastDate.minusYears(1);
+        } catch (DateTimeParseException e) {
+            throw new DiaryLocalDateConverterException(ResponseCode.DIARY_CONVERTER_FAILED);
+        }
     }
 }

--- a/src/main/java/adhd/diary/response/ResponseCode.java
+++ b/src/main/java/adhd/diary/response/ResponseCode.java
@@ -28,6 +28,7 @@ public enum ResponseCode {
     DIARY_READ_BY_ID_SUCCESS(HttpStatus.OK, "일기 조회 성공"),
     DIARY_UPDATE_SUCCESS(HttpStatus.OK, "일기 수정 성공"),
     DIARY_DELETE_SUCCESS(HttpStatus.OK, "일기 삭제 성공"),
+    DIARY_READ_BY_YEAR_SUCCESS(HttpStatus.OK, "작년 일기 정보 조회 성공"),
 
     DIARY_CREATE_SUCCESS(HttpStatus.CREATED, "일기 생성 성공"),
 


### PR DESCRIPTION
### 개요

- 사용자는 1년 전 나의 일기를 조회할 수 있다.

### 반영 브랜치

- `diary-4/last-year` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- 작년 일기 조회 
- 날짜 변환 에러 커스텀 예외 처리
- DiaryLocalDateConverterException의 예외 처리 중 잘못된 예외 객체 수정

### 테스트 결과

- [X] 다이어리 작년 일기 조회 