### PR TITLE
refactor: Diary Response 날짜 형태 수정

### DIFF
--- a/src/main/java/adhd/diary/diary/dto/response/DiaryDateResponse.java
+++ b/src/main/java/adhd/diary/diary/dto/response/DiaryDateResponse.java
@@ -7,13 +7,17 @@ import java.time.LocalDate;
 public record DiaryDateResponse(Long id,
                                 String content,
                                 Emotion emotion,
-                                LocalDate date) {
+                                String date) {
     public DiaryDateResponse(Diary diary) {
         this(
                 diary.getId(),
                 diary.getContent(),
                 diary.getEmotion(),
-                diary.getDate()
+                convertToString(diary.getDate())
         );
+    }
+
+    public static String convertToString(LocalDate date) {
+        return date.toString();
     }
 }

--- a/src/main/java/adhd/diary/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/adhd/diary/diary/dto/response/DiaryResponse.java
@@ -10,7 +10,7 @@ public record DiaryResponse(Long id,
                             String analyzedContents,
                             String recommendSongs,
                             Emotion emotion,
-                            LocalDate date) {
+                            String date) {
 
     public DiaryResponse(Diary diary) {
         this(
@@ -19,7 +19,11 @@ public record DiaryResponse(Long id,
                 diary.getAnalyzedContents(),
                 diary.getRecommendSongs(),
                 diary.getEmotion(),
-                diary.getDate()
+                convertToString(diary.getDate())
         );
+    }
+
+    public static String convertToString(LocalDate date) {
+        return date.toString();
     }
 }

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -77,6 +77,7 @@ public class DiaryService {
     public DiaryResponse findLastYearDiary(String date) {
         Diary diary = diaryRepository.findLastYearByDate(convertLastDate(date))
                 .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));
+        authorizePostMember(diary);
         return new DiaryResponse(diary);
     }
 


### PR DESCRIPTION
### 개요

- 일기장 날짜 형태가 리스트 형태로 반환되는 현상 발견

### 반영 브랜치

- `diary-5/refactor-response` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- DiaryResponse dto에 날짜 형태를 String으로 바꾸는 메서드 추가

### 테스트 결과

- [X] 다이어리 반환 시 스트링 형태로 반환