### PR TITLE
feat: swagger api 상세 정보 작성

### DIFF
--- a/src/main/java/adhd/diary/auth/controller/AuthController.java
+++ b/src/main/java/adhd/diary/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import adhd.diary.auth.exception.token.TokenNotFoundException;
 import adhd.diary.auth.jwt.JwtService;
 import adhd.diary.response.ApiResponse;
 import adhd.diary.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -20,6 +21,7 @@ public class AuthController {
     }
 
     @PostMapping("/api/auth/token/refresh")
+    @Operation(summary = "refreshToken을 이용해 token을 재발급", description = "사용자의 토큰 정보가 만료되었을 경우 재발급 받기 위해 사용하는 API")
     public ApiResponse<?> refreshAccessToken(HttpServletResponse response, @RequestHeader("RefreshToken") String refreshToken) {
         try {
             TokenResponse tokenResponse = jwtService.refreshTokens(refreshToken);

--- a/src/main/java/adhd/diary/auth/controller/LoginController.java
+++ b/src/main/java/adhd/diary/auth/controller/LoginController.java
@@ -6,6 +6,7 @@ import adhd.diary.auth.service.NaverService;
 import adhd.diary.response.ApiResponse;
 import adhd.diary.response.ResponseCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,6 +22,7 @@ public class LoginController {
     }
 
     @GetMapping("/kakao")
+    @Operation(summary = "카카오 소셜 로그인", description = "사용자가 카카오 소셜로그인을 하기 위해 사용하는 API")
     public ApiResponse<SocialLoginResponse> kakaoLogin(@RequestParam String code) throws JsonProcessingException {
         String accessToken = kakaoService.getKakaoAccessToken(code);
         SocialLoginResponse socialLoginResponse = kakaoService.kakaoLogin(accessToken);
@@ -28,6 +30,7 @@ public class LoginController {
     }
 
     @GetMapping("/naver")
+    @Operation(summary = "네이버 소셜 로그인", description = "사용자가 네이버 소셜로그인을 하기 위해 사용하는 API")
     public ApiResponse<SocialLoginResponse> naverLogin(@RequestParam String code) throws JsonProcessingException {
         String accessToken = naverService.getNaverAccessToken(code);
         SocialLoginResponse socialLoginResponse = naverService.naverLogin(accessToken);

--- a/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
@@ -2,6 +2,7 @@ package adhd.diary.chatgpt.controller;
 
 import adhd.diary.chatgpt.dto.ChatMessage;
 import adhd.diary.chatgpt.service.ChatGptService;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,7 @@ public class ChatGptController {
     }
 
     @PostMapping("/chatgpt/diary-analyze")
+    @Operation(summary = "일기 내용 감정 분석", description = "사용자가 작성한 일기 내용으로 감정을 분석하기 위해 사용하는 API")
     public CompletableFuture<ResponseEntity<String>> getAnalyzedDiary(@RequestParam String diaryContents) {
         return chatGptService.analyzeDiary(List.of(new ChatMessage(diaryContents + analyzeSentence)))
                 .thenApply(ResponseEntity::ok)
@@ -36,6 +38,7 @@ public class ChatGptController {
     }
 
     @PostMapping("/chatgpt/recommend-song")
+    @Operation(summary = "일기 내용 바탕 노래 추천", description = "사용자가 작성한 일기 내용을 바탕으로 노래를 추천받기 위해 사용하는 API")
     public CompletableFuture<ResponseEntity<String>> getRecommendSong(@RequestParam String diaryContents) {
         return chatGptService.recommendSong(List.of(new ChatMessage(diaryContents + recommendSongSentence)))
                 .thenApply(ResponseEntity::ok)

--- a/src/main/java/adhd/diary/diary/controller/DiaryController.java
+++ b/src/main/java/adhd/diary/diary/controller/DiaryController.java
@@ -4,6 +4,7 @@ import adhd.diary.diary.dto.response.DiaryDateResponse;
 import adhd.diary.diary.service.DiaryService;
 import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 
 import adhd.diary.response.ApiResponse;
@@ -21,42 +22,42 @@ public class DiaryController {
     }
 
     @PostMapping("/diary")
+    @Operation(summary = "일기 정보를 저장", description = "사용자가 일기를 작성하고 분석까지 진행한 후 일기 정보를 저장하기 위해 사용하는 API")
     public ApiResponse<DiaryResponse> create(@RequestBody DiaryRequest request) {
         DiaryResponse diaryResponse = diaryService.save(request);
         return ApiResponse.success(ResponseCode.DIARY_CREATE_SUCCESS, diaryResponse);
     }
 
     @GetMapping("/diary/{id}")
+    @Operation(summary = "일기 정보를 조회", description = "사용자가 일기의 상세 정보를 조회하기 위해 사용하는 API")
     public ApiResponse<DiaryResponse> diary(@PathVariable Long id) {
         DiaryResponse diaryResponse = diaryService.findById(id);
         return ApiResponse.success(ResponseCode.DIARY_READ_BY_ID_SUCCESS, diaryResponse);
     }
 
     @GetMapping("/diary/dates")
+    @Operation(summary = "일기 날짜, 내용, 감정 정보를 조회", description = "달력에 감정을 표현하기 위해 사용하는 API")
     public ApiResponse<List<DiaryDateResponse>> diaryDate() {
         List<DiaryDateResponse> diaryDateResponse = diaryService.findDatesByEmail();
         return ApiResponse.success(ResponseCode.DIARY_READ_BY_ID_SUCCESS, diaryDateResponse);
     }
 
     @GetMapping("/diary/last-year")
+    @Operation(summary = "작년 일기 정보를 조회", description = "보내준 날짜를 기준으로 1년 전의 일기 정보를 조회하기 위해 사용하는 API")
     public ApiResponse<DiaryResponse> getDiaryFromLastYear(@RequestParam String date) {
         DiaryResponse lastYearDiary = diaryService.findLastYearDiary(date);
         return ApiResponse.success(ResponseCode.DIARY_READ_BY_YEAR_SUCCESS, lastYearDiary);
     }
 
-    @GetMapping("/diarys")
-    public ApiResponse<List<DiaryResponse>> diaryAll() {
-        List<DiaryResponse> diaryResponses = diaryService.findAll();
-        return ApiResponse.success(ResponseCode.DIARY_READ_ALL_SUCCESS, diaryResponses);
-    }
-
     @DeleteMapping("/diary/{id}")
+    @Operation(summary = "일기 정보를 삭제", description = "사용자가 일기의 상세 정보를 삭제하기 위해 사용하는 API")
     public ApiResponse<Void> remove(@PathVariable Long id) {
         diaryService.deleteById(id);
         return ApiResponse.success(ResponseCode.DIARY_DELETE_SUCCESS);
     }
 
     @PutMapping("/diary/{id}")
+    @Operation(summary = "일기 정보를 수정", description = "사용자가 일기의 상세 정보를 수정하기 위해 사용하는 API")
     public ApiResponse<DiaryResponse> update(@PathVariable Long id, @RequestBody DiaryRequest request) {
         DiaryResponse diaryResponse = diaryService.updateById(id, request);
         return ApiResponse.success(ResponseCode.DIARY_UPDATE_SUCCESS, diaryResponse);

--- a/src/main/java/adhd/diary/diary/domain/Emotion.java
+++ b/src/main/java/adhd/diary/diary/domain/Emotion.java
@@ -2,25 +2,32 @@ package adhd.diary.diary.domain;
 
 public enum Emotion {
 
-    HAPPY("기분 좋아"),
-    EXCITED("신나"),
-    AMAZED("놀라워"),
-    SAD("슬퍼"),
-    LOVE("사랑이야"),
-    CURIOUS("궁금해"),
-    DISAPPOINTED("마음에 안들어"),
-    HURT("아파"),
-    IMPRESSED("역시 멋져"),
-    ANGRY("화나"),
-    DIZZY("어질어질해");
+    JUST("그냥", 5),
+    HAPPY("기분 좋아", 8),
+    EXCITED("신나", 9),
+    AMAZED("놀라워", 7),
+    SAD("슬퍼", 2),
+    LOVE("사랑이야", 10),
+    CURIOUS("궁금해", 6),
+    DISAPPOINTED("마음에 안들어", 3),
+    HURT("아파", 1),
+    IMPRESSED("역시 멋져", 9),
+    ANGRY("화나", 2),
+    DIZZY("어질어질해", 4);
 
     private final String type;
+    private final int score;
 
-    Emotion(String type) {
+    Emotion(String type, int score) {
         this.type = type;
+        this.score = score;
     }
 
     public String getType() {
         return type;
+    }
+
+    public int getScore() {
+        return score;
     }
 }

--- a/src/main/java/adhd/diary/member/controller/MemberApiController.java
+++ b/src/main/java/adhd/diary/member/controller/MemberApiController.java
@@ -7,6 +7,7 @@ import adhd.diary.member.dto.request.UpdateNicknameRequest;
 import adhd.diary.member.service.MemberService;
 import adhd.diary.response.ApiResponse;
 import adhd.diary.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -21,6 +22,7 @@ public class MemberApiController {
     }
 
     @PutMapping("/api/update-nickname")
+    @Operation(summary = "사용자 닉네임 수정", description = "사용자가 닉네임을 수정하기 위해 사용하는 API")
     public ApiResponse<?> updateNickname(@RequestBody UpdateNicknameRequest updateNicknameRequest, Principal principal) {
 
         MemberResponse memberResponse = memberService.updateNickname(principal.getName(), updateNicknameRequest.getNickname());
@@ -28,6 +30,7 @@ public class MemberApiController {
     }
 
     @PostMapping("/login/complete-registration")
+    @Operation(summary = "사용자 회원가입 완료", description = "사용자의 회원가입을 완료하기 위해 사용하는 API")
     public ApiResponse<?> completeRegistration (@RequestBody CompleteRegistrationRequest completeRegistrationRequest, Principal principal) {
 
         MemberSignUpResponse memberSignUpResponse = memberService.completeRegistration(completeRegistrationRequest, principal.getName());


### PR DESCRIPTION
### 개요

- 프론트엔드와의 협업을 향상시키기 위한 Swagger 상세 정보 작성

### 반영 브랜치

- `swagger-ui/operation` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- 각 컨트롤러에 api에 대한 상세 정보 작성

### 테스트 결과

- [X] Swagger UI를 통한 상세 정보 확인