### PR TITLE
feat: diary apI 추가

### DIFF
--- a/src/main/java/adhd/diary/diary/controller/DiaryController.java
+++ b/src/main/java/adhd/diary/diary/controller/DiaryController.java
@@ -1,6 +1,7 @@
 package adhd.diary.diary.controller;
 
 import adhd.diary.diary.dto.response.DiaryDateResponse;
+import adhd.diary.diary.dto.response.DiaryWeekendResponse;
 import adhd.diary.diary.service.DiaryService;
 import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryResponse;
@@ -47,6 +48,13 @@ public class DiaryController {
     public ApiResponse<DiaryResponse> getDiaryFromLastYear(@RequestParam String date) {
         DiaryResponse lastYearDiary = diaryService.findLastYearDiary(date);
         return ApiResponse.success(ResponseCode.DIARY_READ_BY_YEAR_SUCCESS, lastYearDiary);
+    }
+
+    @GetMapping("/diary/weekends")
+    @Operation(summary = "일주일 달력 정보를 조회", description = "(임시) 보내준 날짜")
+    public ApiResponse<List<DiaryWeekendResponse>> getWeekendDiaries() {
+        List<DiaryWeekendResponse> diaryWeekendResponses = diaryService.findWeekendsDiaries();
+        return ApiResponse.success(ResponseCode.DIARY_READ_WEEKEND, diaryWeekendResponses);
     }
 
     @DeleteMapping("/diary/{id}")

--- a/src/main/java/adhd/diary/diary/domain/DiaryRepository.java
+++ b/src/main/java/adhd/diary/diary/domain/DiaryRepository.java
@@ -6,11 +6,16 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<List<Diary>> findByMemberId(Long memberId);
 
-    @Query("SELECT d FROM Diary d WHERE d.date = :targetDate")
+    @Query(value = "SELECT d FROM diary d WHERE d.date = :targetDate", nativeQuery = true)
     Optional<Diary> findLastYearByDate(@Param("targetDate") LocalDate targetDate);
+
+    @Query(value = "SELECT * FROM diary d WHERE d.member_id = :memberId AND d.date BETWEEN '2024-07-28' AND '2024-08-03'", nativeQuery = true)
+    Optional<List<Diary>> findWeekeendByMemberId(Long memberId);
 }

--- a/src/main/java/adhd/diary/diary/dto/response/DiaryWeekendResponse.java
+++ b/src/main/java/adhd/diary/diary/dto/response/DiaryWeekendResponse.java
@@ -1,0 +1,24 @@
+package adhd.diary.diary.dto.response;
+
+import adhd.diary.diary.domain.Diary;
+import adhd.diary.diary.domain.Emotion;
+import java.time.LocalDate;
+
+public record DiaryWeekendResponse(Long id,
+                                   Emotion emotion,
+                                   int score,
+                                   String date) {
+    public DiaryWeekendResponse(Diary diary) {
+        this(
+                diary.getId(),
+                diary.getEmotion(),
+                diary.getEmotion().getScore(),
+                convertToString(diary.getDate())
+        );
+    }
+
+    public static String convertToString(LocalDate date) {
+        return date.toString();
+    }
+
+}

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -5,6 +5,7 @@ import adhd.diary.diary.domain.DiaryRepository;
 import adhd.diary.diary.dto.request.DiaryRequest;
 import adhd.diary.diary.dto.response.DiaryDateResponse;
 import adhd.diary.diary.dto.response.DiaryResponse;
+import adhd.diary.diary.dto.response.DiaryWeekendResponse;
 import adhd.diary.diary.exception.DiaryForbiddenException;
 import adhd.diary.diary.exception.DiaryLocalDateConverterException;
 import adhd.diary.diary.exception.DiaryNotFoundException;
@@ -79,6 +80,15 @@ public class DiaryService {
                 .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));
         authorizePostMember(diary);
         return new DiaryResponse(diary);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DiaryWeekendResponse> findWeekendsDiaries() {
+        Member member = memberRepository.findByEmail(getAuthenticationMemberEmail())
+                .orElseThrow(() -> new MemberNotFoundException(ResponseCode.MEMBER_NOT_FOUND));
+        List<Diary> diaries = diaryRepository.findWeekeendByMemberId(member.getId())
+                .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));
+        return diaries.stream().map(DiaryWeekendResponse::new).toList();
     }
 
     @Transactional

--- a/src/main/java/adhd/diary/response/ResponseCode.java
+++ b/src/main/java/adhd/diary/response/ResponseCode.java
@@ -29,6 +29,7 @@ public enum ResponseCode {
     DIARY_UPDATE_SUCCESS(HttpStatus.OK, "일기 수정 성공"),
     DIARY_DELETE_SUCCESS(HttpStatus.OK, "일기 삭제 성공"),
     DIARY_READ_BY_YEAR_SUCCESS(HttpStatus.OK, "작년 일기 정보 조회 성공"),
+    DIARY_READ_WEEKEND(HttpStatus.OK, "주간 일기 정보 조회 성공"),
 
     DIARY_CREATE_SUCCESS(HttpStatus.CREATED, "일기 생성 성공"),
 


### PR DESCRIPTION
### 개요

- 사용자는 일주일 일기 정보를 분석할 수 있다.

### 반영 브랜치

- `diary-7/refactor-api` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- 사용자의 일주일 일기 정보 조회를 위한 쿼리 작성
- 사용자의 일주일 일기 정보 반환을 위한 레코드 객체 생성

### 테스트 결과

- [X] 사용자의 일주일 일기 정보 조회