### PR TITLE
refactor: 유저 메일로 일기 정보 가져오기 수정

### DIFF
--- a/src/main/java/adhd/diary/diary/domain/DiaryRepository.java
+++ b/src/main/java/adhd/diary/diary/domain/DiaryRepository.java
@@ -13,7 +13,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<List<Diary>> findByMemberId(Long memberId);
 
-    @Query(value = "SELECT d FROM diary d WHERE d.date = :targetDate", nativeQuery = true)
+    @Query(value = "SELECT * FROM diary d WHERE d.date = :targetDate", nativeQuery = true)
     Optional<Diary> findLastYearByDate(@Param("targetDate") LocalDate targetDate);
 
     @Query(value = "SELECT * FROM diary d WHERE d.member_id = :memberId AND d.date BETWEEN '2024-07-28' AND '2024-08-03'", nativeQuery = true)

--- a/src/main/java/adhd/diary/diary/service/DiaryService.java
+++ b/src/main/java/adhd/diary/diary/service/DiaryService.java
@@ -70,7 +70,6 @@ public class DiaryService {
                 .orElseThrow(() -> new MemberNotFoundException(ResponseCode.MEMBER_NOT_FOUND));
         List<Diary> diaries = diaryRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new DiaryNotFoundException(ResponseCode.DIARY_NOT_FOUND));
-        authorizePostMember(diaries.get(0));
         return diaries.stream().map(DiaryDateResponse::new).toList();
     }
 


### PR DESCRIPTION
### 개요

- 사용자 로그인 정보로 일기 정보 가져올 때 쿼리 이슈 발생

### 반영 브랜치

- `diary-8/refactor-api` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- nativeQuery = true 설정으로 JPA query 수정

### 테스트 결과

- [X] 회원이 작성한 일기 정보들을 정상적으로 조회