### PR TITLE
refactor: chatgpt-api 비동기에서 동기 요청으로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,13 +55,13 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
-processResources.dependsOn('copySecret')
-
-tasks.register('copySecret', Copy) {
-	from './server-submodule'
-	include "application*.yml"
-	into './src/main/resources'
-}
+//processResources.dependsOn('copySecret')
+//
+//tasks.register('copySecret', Copy) {
+//	from './server-submodule'
+//	include "application*.yml"
+//	into './src/main/resources'
+//}
 
 tasks.named("jar") {
 	enabled = false;

--- a/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/adhd/diary/chatgpt/controller/ChatGptController.java
@@ -29,19 +29,17 @@ public class ChatGptController {
         this.chatGptService = chatGptService;
     }
 
-    @PostMapping("/chatgpt/diary-analyze")
+    @PostMapping("/chatgpt/diary-analyzes")
     @Operation(summary = "일기 내용 감정 분석", description = "사용자가 작성한 일기 내용으로 감정을 분석하기 위해 사용하는 API")
-    public CompletableFuture<ResponseEntity<String>> getAnalyzedDiary(@RequestParam String diaryContents) {
-        return chatGptService.analyzeDiary(List.of(new ChatMessage(diaryContents + analyzeSentence)))
-                .thenApply(ResponseEntity::ok)
-                .exceptionally(e -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error : " + e.getMessage()));
+    public ResponseEntity<String> getAnalyzedDiary(@RequestParam String diaryContents) {
+        String response = chatGptService.analyzeDiary(List.of(new ChatMessage(diaryContents + analyzeSentence)));
+        return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/chatgpt/recommend-song")
+    @PostMapping("/chatgpt/recommend-songs")
     @Operation(summary = "일기 내용 바탕 노래 추천", description = "사용자가 작성한 일기 내용을 바탕으로 노래를 추천받기 위해 사용하는 API")
-    public CompletableFuture<ResponseEntity<String>> getRecommendSong(@RequestParam String diaryContents) {
-        return chatGptService.recommendSong(List.of(new ChatMessage(diaryContents + recommendSongSentence)))
-                .thenApply(ResponseEntity::ok)
-                .exceptionally(e -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Error : " + e.getMessage()));
+    public ResponseEntity<String> getRecommendSong(@RequestParam String diaryContents) {
+        String response = chatGptService.recommendSong(List.of(new ChatMessage(diaryContents + recommendSongSentence)));
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/adhd/diary/chatgpt/service/ChatGptService.java
+++ b/src/main/java/adhd/diary/chatgpt/service/ChatGptService.java
@@ -6,6 +6,7 @@ import adhd.diary.chatgpt.util.ChatGptUtil;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,11 +27,11 @@ public class ChatGptService {
         this.chatGptUtil = chatGptUtil;
     }
 
-    public CompletableFuture<String> analyzeDiary(List<ChatMessage> messages) {
+    public String analyzeDiary(List<ChatMessage> messages) {
         return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
     }
 
-    public CompletableFuture<String> recommendSong(List<ChatMessage> messages) {
+    public String recommendSong(List<ChatMessage> messages) {
         return chatGptUtil.createChatCompletion(toChatCompletionRequest(messages), API_URL);
     }
 


### PR DESCRIPTION
### 개요

- GPT 응답은 받으나 클라이언트 전달이 안되는 이슈

### 반영 브랜치

- `diary-9/refactor-chatgpt-api` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- chatGPT 비동기 통신을 동기 통신으로 변경 후 
- 반환 형태 CompletableFuture 에서 ResponseEntity로 변환

### 테스트 결과

- [X] GPT 응답이 client로 잘 전달